### PR TITLE
Use pip install instead of python setup.py install

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 2
   noarch: python
-  script: pip install .
+  script: python -m pip install --no-deps .
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,9 @@ source:
   sha256: fae4cffc040921b8a2d60c6cf0b5d662c1190fe54d718271db4eb17d44a185b7
 
 build:
-  number: 1
+  number: 2
   noarch: python
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  script: pip install .
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ requirements:
   build:
     - python
     - setuptools
+    - pip
   run:
     - python
 


### PR DESCRIPTION
Using 'python setup.py install' to build the pytz package as a noarch
package will cause a python version specific egg-info file to be
generated. To build a really noarch, no python version package a wheel
has to be made instead. Turns out that pip knows how to do that. Using
'pip install .' instead makes a wheel distribution and the resulting
conda package is capable of being used in either py27 and py3x
environments.